### PR TITLE
refactor: remove unused BaseDomainModel.to_dict() method

### DIFF
--- a/backend/domain/models/base.py
+++ b/backend/domain/models/base.py
@@ -1,10 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 
 @dataclass
 class BaseDomainModel:
     """Base class for all domain models."""
-
-    def to_dict(self):
-        """Convert the domain model to a dictionary."""
-        return asdict(self)


### PR DESCRIPTION
## Summary
Removes the unused `to_dict()` method from `BaseDomainModel` class.

## Related Issue
Fixes #16

## Changes
- Removed `to_dict()` method that was never called
- Removed unused `asdict` import from `dataclasses`

## Verification
Searched entire codebase for `.to_dict()` calls - none found. All API responses use Pydantic's `model_validate()` instead.